### PR TITLE
Fix package.json's test & lint commands.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "scripts": {
     "start": "meteor run",
     "test": "npm run lint && chimp --mocha --path=tests",
-    "lint": "eslint . --ext .jsx, js",
-    "fix": "eslint . --ext .jsx, js --fix",
+    "lint": "eslint --ext .jsx,.js .",
+    "fix": "eslint --ext .jsx,.js --fix .",
     "watch": "chimp --ddp=http://localhost:3000 --watch --mocha --path=tests"
   },
   "dependencies": {


### PR DESCRIPTION
The previous syntax would scan only `jsx` files.
